### PR TITLE
Support CensoredASM's onDemandAnimatedTextures feature

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     buildDependencies fg.deobf('curse.maven:ChunkAnimator-236484:3850023')
     buildDependencies fg.deobf('curse.maven:FluidloggedAPI-485654:3956311')
     buildDependencies fg.deobf('curse.maven:CubicChunks-292243:3546640')
+    buildDependencies fg.deobf('curse.maven:CensoredASM-460609:4800875')
 }
 
 minecraft {

--- a/src/main/java/meldexun/nothirium/api/renderer/chunk/IChunkRenderer.java
+++ b/src/main/java/meldexun/nothirium/api/renderer/chunk/IChunkRenderer.java
@@ -1,6 +1,7 @@
 package meldexun.nothirium.api.renderer.chunk;
 
 import java.nio.ByteBuffer;
+import java.util.List;
 
 import meldexun.nothirium.api.renderer.IVBOPart;
 import meldexun.renderlib.util.Frustum;
@@ -12,6 +13,8 @@ public interface IChunkRenderer<T extends IRenderChunk> {
 	int renderedChunks();
 
 	int renderedChunks(ChunkRenderPass pass);
+
+	List<T> getRenderChunks();
 
 	void init(int renderDistance);
 

--- a/src/main/java/meldexun/nothirium/api/renderer/chunk/IRenderChunk.java
+++ b/src/main/java/meldexun/nothirium/api/renderer/chunk/IRenderChunk.java
@@ -4,6 +4,9 @@ import javax.annotation.Nullable;
 
 import meldexun.nothirium.api.renderer.IVBOPart;
 import meldexun.nothirium.util.SectionPos;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+
+import java.util.Set;
 
 public interface IRenderChunk {
 
@@ -39,6 +42,8 @@ public interface IRenderChunk {
 	IVBOPart getVBOPart(ChunkRenderPass pass);
 
 	void setVBOPart(ChunkRenderPass pass, @Nullable IVBOPart vboPart);
+
+	Set<TextureAtlasSprite> getVisibleTextures();
 
 	boolean isEmpty();
 

--- a/src/main/java/meldexun/nothirium/mc/integration/CensoredASM.java
+++ b/src/main/java/meldexun/nothirium/mc/integration/CensoredASM.java
@@ -1,0 +1,57 @@
+package meldexun.nothirium.mc.integration;
+
+import com.google.common.collect.ImmutableSet;
+import meldexun.nothirium.api.renderer.chunk.IRenderChunk;
+import meldexun.nothirium.mc.renderer.ChunkRenderManager;
+import meldexun.nothirium.mc.vertex.ExtendedBufferBuilder;
+import net.minecraft.client.renderer.chunk.CompiledChunk;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraftforge.fml.common.Loader;
+import zone.rong.loliasm.client.sprite.ondemand.IAnimatedSpriteActivator;
+import zone.rong.loliasm.client.sprite.ondemand.IAnimatedSpritePrimer;
+import zone.rong.loliasm.client.sprite.ondemand.IBufferPrimerConfigurator;
+import zone.rong.loliasm.client.sprite.ondemand.ICompiledChunkExpander;
+
+import java.util.Set;
+
+public class CensoredASM {
+    // Simple hack to check if onDemandAnimatedTextures is enabled
+    private static final boolean LOADED = Loader.isModLoaded("loliasm") && IAnimatedSpriteActivator.class.isAssignableFrom(TextureAtlasSprite.class);
+
+    public static void startCapturingChunkTextures() {
+        if(!LOADED)
+            return;
+        IAnimatedSpritePrimer.CURRENT_COMPILED_CHUNK.set(new CompiledChunk());
+    }
+
+    public static Set<TextureAtlasSprite> stopCapturingChunkTextures() {
+        if(!LOADED)
+            return ImmutableSet.of();
+        CompiledChunk c = IAnimatedSpritePrimer.CURRENT_COMPILED_CHUNK.get();
+        if(c instanceof ICompiledChunkExpander)
+            return ((ICompiledChunkExpander)c).getVisibleTextures();
+        else
+            return ImmutableSet.of();
+    }
+
+
+    public static void triggerSpriteOnBufferAccess(ExtendedBufferBuilder builder, float u, float v) {
+        if(LOADED && builder instanceof IBufferPrimerConfigurator) {
+            try {
+                ((IBufferPrimerConfigurator)builder).hookTexture(u, v);
+            } catch(Throwable e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    public static void activateChunkSprites() {
+        if(!LOADED)
+            return;
+        for(IRenderChunk c : ChunkRenderManager.getRenderer().getRenderChunks()) {
+            for(TextureAtlasSprite sprite : c.getVisibleTextures()) {
+                ((IAnimatedSpriteActivator)sprite).setActive(true);
+            }
+        }
+    }
+}

--- a/src/main/java/meldexun/nothirium/mc/mixin/MixinTextureMap.java
+++ b/src/main/java/meldexun/nothirium/mc/mixin/MixinTextureMap.java
@@ -1,0 +1,19 @@
+package meldexun.nothirium.mc.mixin;
+
+import meldexun.nothirium.mc.integration.CensoredASM;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.texture.TextureMap;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(value = TextureMap.class, priority = 1100)
+public class MixinTextureMap {
+    @Inject(method = "updateAnimations", at = @At("HEAD"))
+    private void triggerChunkSprites(CallbackInfo ci) {
+        if(((TextureMap)(Object)this) == Minecraft.getMinecraft().getTextureMapBlocks()) {
+            CensoredASM.activateChunkSprites();
+        }
+    }
+}

--- a/src/main/java/meldexun/nothirium/mc/renderer/chunk/RenderChunkTaskCompile.java
+++ b/src/main/java/meldexun/nothirium/mc/renderer/chunk/RenderChunkTaskCompile.java
@@ -1,10 +1,13 @@
 package meldexun.nothirium.mc.renderer.chunk;
 
 import java.util.Arrays;
+import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.stream.IntStream;
 
+import meldexun.nothirium.mc.integration.CensoredASM;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import org.lwjgl.opengl.GL11;
 
 import meldexun.nothirium.api.renderer.chunk.ChunkRenderPass;
@@ -103,6 +106,8 @@ public class RenderChunkTaskCompile extends AbstractRenderChunkTask<RenderChunk>
 		MutableBlockPos pos = new MutableBlockPos();
 		VisibilityGraph visibilityGraph = new VisibilityGraph();
 
+		CensoredASM.startCapturingChunkTextures();
+
 		for (int x = 0; x < 16; x++) {
 			for (int y = 0; y < 16; y++) {
 				for (int z = 0; z < 16; z++) {
@@ -120,6 +125,8 @@ public class RenderChunkTaskCompile extends AbstractRenderChunkTask<RenderChunk>
 				return RenderChunkTaskResult.CANCELLED;
 			}
 		}
+
+		Set<TextureAtlasSprite> visibleTextures = CensoredASM.stopCapturingChunkTextures();
 
 		VisibilitySet visibilitySet = visibilityGraph.compute();
 
@@ -156,6 +163,7 @@ public class RenderChunkTaskCompile extends AbstractRenderChunkTask<RenderChunk>
 			try {
 				if (!this.canceled()) {
 					this.renderChunk.setVisibility(visibilitySet);
+					this.renderChunk.setVisibleTextures(visibleTextures);
 					for (ChunkRenderPass pass : ChunkRenderPass.ALL) {
 						BufferBuilder bufferBuilder = finishedBufferBuilders[pass.ordinal()];
 						if (bufferBuilder == null) {

--- a/src/main/java/meldexun/nothirium/mc/vertex/TextureCoordinateUploader.java
+++ b/src/main/java/meldexun/nothirium/mc/vertex/TextureCoordinateUploader.java
@@ -1,6 +1,7 @@
 package meldexun.nothirium.mc.vertex;
 
 import meldexun.matrixutil.UnsafeUtil;
+import meldexun.nothirium.mc.integration.CensoredASM;
 import net.minecraft.client.renderer.vertex.VertexFormatElement;
 import sun.misc.Unsafe;
 
@@ -13,6 +14,7 @@ public class TextureCoordinateUploader {
 			long address = buffer.getAddress() + buffer.getOffset();
 			unsafe.putFloat(address, (float) u);
 			unsafe.putFloat(address + 4, (float) v);
+			CensoredASM.triggerSpriteOnBufferAccess(buffer, (float)u, (float)v);
 		}
 
 		@Override

--- a/src/main/java/meldexun/nothirium/renderer/chunk/AbstractChunkRenderer.java
+++ b/src/main/java/meldexun/nothirium/renderer/chunk/AbstractChunkRenderer.java
@@ -25,6 +25,7 @@ public abstract class AbstractChunkRenderer<T extends AbstractRenderChunk> imple
 	private double lastTransparencyResortZ;
 	private int renderedChunks;
 	protected final Enum2ObjMap<ChunkRenderPass, List<T>> chunks = new Enum2ObjMap<>(ChunkRenderPass.class, (Supplier<List<T>>) ArrayList::new);
+	protected final List<T> chunksAnyPass = new ArrayList<>();
 
 	protected AbstractChunkRenderer() {
 
@@ -40,6 +41,10 @@ public abstract class AbstractChunkRenderer<T extends AbstractRenderChunk> imple
 		return chunks.get(pass).size();
 	}
 
+	public List<T> getRenderChunks() {
+		return chunksAnyPass;
+	}
+
 	@Override
 	public void setup(IRenderChunkProvider<T> renderChunkProvider, double cameraX, double cameraY, double cameraZ, Frustum frustum, int frame) {
 		this.resortTransparency(cameraX, cameraY, cameraZ, frustum);
@@ -50,6 +55,7 @@ public abstract class AbstractChunkRenderer<T extends AbstractRenderChunk> imple
 
 		renderedChunks = 0;
 		chunks.forEach(List::clear);
+		chunksAnyPass.clear();
 		T rootRenderChunk = renderChunkProvider.getRenderChunkAt(chunkX, chunkY, chunkZ);
 		rootRenderChunk.visibleDirections = 0x3F;
 		chunkQueue.add(rootRenderChunk);
@@ -127,6 +133,7 @@ public abstract class AbstractChunkRenderer<T extends AbstractRenderChunk> imple
 				list.add(renderChunk);
 			}
 		});
+		chunksAnyPass.add(renderChunk);
 	}
 
 	protected abstract boolean isSpectator();

--- a/src/main/java/meldexun/nothirium/renderer/chunk/AbstractRenderChunk.java
+++ b/src/main/java/meldexun/nothirium/renderer/chunk/AbstractRenderChunk.java
@@ -1,10 +1,12 @@
 package meldexun.nothirium.renderer.chunk;
 
 import java.util.Arrays;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import javax.annotation.Nullable;
 
+import com.google.common.collect.ImmutableSet;
 import meldexun.nothirium.api.renderer.IVBOPart;
 import meldexun.nothirium.api.renderer.chunk.ChunkRenderPass;
 import meldexun.nothirium.api.renderer.chunk.IChunkRenderer;
@@ -19,6 +21,7 @@ import meldexun.nothirium.util.collection.Enum2ObjMap;
 import meldexun.nothirium.util.math.MathUtil;
 import meldexun.renderlib.util.Frustum;
 import meldexun.renderlib.util.memory.UnsafeByteBuffer;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 
 public abstract class AbstractRenderChunk implements IRenderChunk {
 
@@ -27,6 +30,7 @@ public abstract class AbstractRenderChunk implements IRenderChunk {
 	public int lastTimeEnqueued = -1;
 	public int lastTimeRecorded = -1;
 	private VisibilitySet visibilitySet = new VisibilitySet();
+	private Set<TextureAtlasSprite> visibleTextures = ImmutableSet.of();
 	public int visibleDirections;
 	private boolean dirty;
 	private IRenderChunkTask lastCompileTask;
@@ -71,6 +75,14 @@ public abstract class AbstractRenderChunk implements IRenderChunk {
 
 	public void setVisibility(VisibilitySet visibilitySet) {
 		this.visibilitySet = visibilitySet;
+	}
+
+	public void setVisibleTextures(Set<TextureAtlasSprite> visibleTextures) {
+		this.visibleTextures = visibleTextures;
+	}
+
+	public Set<TextureAtlasSprite> getVisibleTextures() {
+		return visibleTextures;
 	}
 
 	public boolean isFogCulled(double cameraX, double cameraY, double cameraZ, double fogEndSqr) {

--- a/src/main/resources/mixins.nothirium.json
+++ b/src/main/resources/mixins.nothirium.json
@@ -16,7 +16,8 @@
     "MixinBetterBiomeBlend",
     "MixinBlock",
     "MixinGuiOverlayDebug",
-    "MixinRenderGlobal"
+    "MixinRenderGlobal",
+    "MixinTextureMap"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
The patch has been structured to involve minimal changes to Nothirium's codebase; the code that interacts with CensoredASM directly is in a separate class.

Note that this requires CensoredASM 5.18 to work correctly; I have not implemented a version restriction in the initial version of this PR.