### PR TITLE
Fix #63 Compact Machine wall rendering, Use MixinBooter in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,18 +32,34 @@ repositories {
     }
 
     maven { url = 'https://www.cursemaven.com' }
+
+    maven { url = 'https://maven.cleanroommc.com' }
 }
 
 dependencies {
     minecraft "net.minecraftforge:forge:${mc_version}-${forge_version}"
-    implementation "org.spongepowered:mixin:${mixin_version}"
-    annotationProcessor "org.spongepowered:mixin:${mixin_version}:processor"
+    // implementation "org.spongepowered:mixin:${mixin_version}"
+    // annotationProcessor "org.spongepowered:mixin:${mixin_version}:processor"
+
+    // Common:
+    annotationProcessor 'org.ow2.asm:asm-debug-all:5.2'
+    annotationProcessor 'com.google.guava:guava:32.1.2-jre'
+    annotationProcessor 'com.google.code.gson:gson:2.8.9'
+
+    // ForgeGradle:
+    implementation ('zone.rong:mixinbooter:8.8') {
+        transitive = false
+    }
+    annotationProcessor ('zone.rong:mixinbooter:8.8') {
+        transitive = false
+    }
 
     atDependencies fg.deobf('meldexun:RenderLib:1.12.2-1.3.1@jar')
 
     buildDependencies fg.deobf('curse.maven:ChunkAnimator-236484:3850023')
     buildDependencies fg.deobf('curse.maven:FluidloggedAPI-485654:3956311')
     buildDependencies fg.deobf('curse.maven:CubicChunks-292243:3546640')
+    buildDependencies fg.deobf('curse.maven:CompactMachines-224218:2707509')
 }
 
 minecraft {

--- a/src/main/java/meldexun/nothirium/mc/asm/NothiriumEarlyMixinLoader.java
+++ b/src/main/java/meldexun/nothirium/mc/asm/NothiriumEarlyMixinLoader.java
@@ -1,0 +1,15 @@
+package meldexun.nothirium.mc.asm;
+
+import java.util.List;
+
+import com.google.common.collect.Lists;
+import zone.rong.mixinbooter.IEarlyMixinLoader;
+
+public class NothiriumEarlyMixinLoader implements IEarlyMixinLoader {
+
+	@Override
+	public List<String> getMixinConfigs() {
+		return Lists.newArrayList("mixins.nothirium.json");
+	}
+
+}

--- a/src/main/java/meldexun/nothirium/mc/asm/NothiriumLateMixinLoader.java
+++ b/src/main/java/meldexun/nothirium/mc/asm/NothiriumLateMixinLoader.java
@@ -1,0 +1,25 @@
+package meldexun.nothirium.mc.asm;
+
+import java.util.List;
+
+import com.google.common.collect.Lists;
+import net.minecraftforge.fml.common.Loader;
+import zone.rong.mixinbooter.ILateMixinLoader;
+
+public class NothiriumLateMixinLoader implements ILateMixinLoader {
+
+	@Override
+	public List<String> getMixinConfigs() {
+		return Lists.newArrayList("mixins.mods.compactmachines.json");
+	}
+
+	@Override
+	public boolean shouldMixinConfigQueue(String mixinConfig) {
+		switch (mixinConfig) {
+			case "mixins.mods.compactmachines.json":
+				return Loader.isModLoaded("compactmachines3");
+		}
+		return true;
+	}
+
+}

--- a/src/main/java/meldexun/nothirium/mc/mixin/MixinCompactMachines.java
+++ b/src/main/java/meldexun/nothirium/mc/mixin/MixinCompactMachines.java
@@ -1,0 +1,46 @@
+package meldexun.nothirium.mc.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.BlockPos.MutableBlockPos;
+import net.minecraft.util.math.BlockPos.PooledMutableBlockPos;
+import net.minecraft.world.IBlockAccess;
+import org.dave.compactmachines3.init.Blockss;
+import org.dave.compactmachines3.misc.CubeTools;
+import org.dave.compactmachines3.reference.EnumMachineSize;
+
+@Mixin(value = CubeTools.class, remap = false)
+public class MixinCompactMachines {
+
+	@Unique
+	private static int nothirium$getCubeSizeWithYContext(IBlockAccess section, MutableBlockPos pos) {
+		pos.setPos(pos.getX() * 1024, pos.getY(), pos.getZ());
+		for (int i = EnumMachineSize.values().length - 1; i >= 0; i--) {
+			EnumMachineSize size = EnumMachineSize.values()[i];
+			// (x + dimension, y, z)
+			pos.move(EnumFacing.EAST, size.getDimension());
+			if (section.getBlockState(pos).getBlock() == Blockss.wall) {
+				return size.getDimension();
+			}
+			pos.move(EnumFacing.WEST, size.getDimension());
+		}
+		return EnumMachineSize.TINY.getDimension();
+	}
+
+	@Redirect(method = "shouldSideBeRendered", at = @At(value = "INVOKE", target = "Lorg/dave/compactmachines3/reference/EnumMachineSize;getDimension()I"))
+	private static int reassignSize(EnumMachineSize instance, IBlockAccess world, BlockPos pos) {
+		PooledMutableBlockPos mPos = PooledMutableBlockPos.retain(pos);
+		try {
+			return nothirium$getCubeSizeWithYContext(world, mPos.setPos(pos.getX() / 1024, pos.getY(), 0));
+		} finally {
+			// Have to manually release in 1.12
+			mPos.release();
+		}
+	}
+
+}

--- a/src/main/resources/mixins.mods.compactmachines.json
+++ b/src/main/resources/mixins.mods.compactmachines.json
@@ -1,0 +1,15 @@
+{
+  "required": true,
+  "minVersion": "0.8",
+  "package": "meldexun.nothirium.mc.mixin",
+  "compatibilityLevel": "JAVA_8",
+  "refmap": "mixins.nothirium.refmap.json",
+  "mixins": [
+  ],
+  "client": [
+    "MixinCompactMachines"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}


### PR DESCRIPTION
This PR fixes #63 by mixing into Compact Machines, making few changes to Nothirium's existing codebase. See the latest comment in the issue for details on why this is necessary and is only exhibited with Nothirium 0.2.x+ and not older versions/vanilla.

Because this patch requires mixing into a (non-core) mod, I utilize `ILateMixinLoader` from MixinBooter, so MixinBooter is required for this patch to apply. I tried my best to keep compatibility with MixinBoostrap, so Nothirium _should_ still work with either MixinBootstrap or MixinBooter, but MixinBooter is required to specifically fix the Compact Machines walls. As such, I did not include any strict checks for MixinBooter.

Changes build.gradle to use MixinBooter hopefully without any issues. Also, apologies for any formatting issues.